### PR TITLE
[Feature/login] Jwt LocalThread를 통한 인증 정보 처리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ group = 'com.se_community'
 version = '0.0.1-SNAPSHOT'
 
 java {
-    sourceCompatibility = '11'
+    sourceCompatibility = "16"
 }
 
 configurations {
@@ -30,8 +30,21 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+    // jwt
+    implementation('io.jsonwebtoken:jjwt-api:0.11.5')
+    implementation('io.jsonwebtoken:jjwt-impl:0.11.5')
+    implementation('io.jsonwebtoken:jjwt-jackson:0.11.5')
+
+    //swagger springdoc
+    implementation 'org.springdoc:springdoc-openapi-ui:1.7.0'
+
+    // spring actuator
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
 }
 
 tasks.named('test') {
     useJUnitPlatform()
 }
+targetCompatibility = JavaVersion.VERSION_16

--- a/src/main/java/com/core/service/auth/application/AuthService.java
+++ b/src/main/java/com/core/service/auth/application/AuthService.java
@@ -1,0 +1,48 @@
+package com.core.service.auth.application;
+
+import com.core.service.auth.domain.UserDetail;
+import com.core.service.auth.dto.request.JoinRequest;
+import com.core.service.auth.token.TokenProvider;
+import com.core.service.error.dto.ErrorMessage;
+import com.core.service.error.exception.member.NotExistMemberException;
+import com.core.service.member.domain.Member;
+import com.core.service.member.infrastructure.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+    private final TokenProvider tokenProvider;
+
+    private final MemberRepository memberRepository;
+
+    /**
+     * @brief      * 유저 조회
+     * @param      * id : 파싱한 token Long userID
+     * @return     * userId 조회를 통한 UserDetail
+     */
+    @Transactional(readOnly = true)
+    public UserDetail loadUserById(Long id) {
+        var member =  memberRepository.findById(id)
+                .orElseThrow(() -> new NotExistMemberException(ErrorMessage.NOT_EXIST_MEMBER_EXCEPTION, "해당 유저 정보가 존재하지 않습니다."));
+
+        return new UserDetail(member);
+    }
+
+    /**
+     * @brief      * 유저 로그인
+     * @param      * JoinRequest : 로그인을 위한 email, password
+     * @return     * jwt token : 조회한 유저 정보 id, role 이용한 jwt token
+     */
+    @Transactional(readOnly = true)
+    public String userLogin(JoinRequest joinRequest){
+        Member member = memberRepository.findByEmailAndPassword(joinRequest.email(), joinRequest.password())
+                .orElseThrow(
+                () -> new NotExistMemberException(ErrorMessage.NOT_EXIST_MEMBER_EXCEPTION, "해당 유저 정보가 존재하지 않습니다.")
+        );
+        return tokenProvider.generateJwtToken(member.getId(), member.getRoleType().getRole());
+    }
+    
+}

--- a/src/main/java/com/core/service/auth/domain/Authentication.java
+++ b/src/main/java/com/core/service/auth/domain/Authentication.java
@@ -1,0 +1,5 @@
+package com.core.service.auth.domain;
+import com.core.service.member.domain.vo.RoleType;
+
+public record Authentication(UserDetail userDetail, RoleType roleType) {
+}

--- a/src/main/java/com/core/service/auth/domain/UserDetail.java
+++ b/src/main/java/com/core/service/auth/domain/UserDetail.java
@@ -10,7 +10,7 @@ public class UserDetail {
     private String userEmail;
     private String userPassword;
     private String name;
-    private String grade;
+    private Long grade;
     private String classNumber;
     private RoleType roleType;
 

--- a/src/main/java/com/core/service/auth/domain/UserDetail.java
+++ b/src/main/java/com/core/service/auth/domain/UserDetail.java
@@ -1,0 +1,26 @@
+package com.core.service.auth.domain;
+
+import com.core.service.member.domain.Member;
+import com.core.service.member.domain.vo.RoleType;
+import lombok.Getter;
+
+@Getter
+public class UserDetail {
+    private Long id;
+    private String userEmail;
+    private String userPassword;
+    private String name;
+    private String grade;
+    private String classNumber;
+    private RoleType roleType;
+
+    public UserDetail(Member member) {
+        this.id = member.getId();
+        this.userEmail = member.getEmail();
+        this.userPassword = member.getPassword();
+        this.name = member.getName();
+        this.grade = member.getGrade();
+        this.classNumber = member.getClassNumber();
+        this.roleType = member.getRoleType();
+    }
+}

--- a/src/main/java/com/core/service/auth/dto/request/JoinRequest.java
+++ b/src/main/java/com/core/service/auth/dto/request/JoinRequest.java
@@ -1,0 +1,5 @@
+package com.core.service.auth.dto.request;
+
+
+public record JoinRequest(String email, String password) {
+}

--- a/src/main/java/com/core/service/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/core/service/auth/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,40 @@
+package com.core.service.auth.filter;
+
+import com.core.service.auth.infrastructure.LocalContextHolder;
+import com.core.service.auth.token.TokenProvider;
+import com.core.service.common.header.HeaderUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.filter.GenericFilterBean;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.util.Optional;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends GenericFilterBean {
+    private final TokenProvider tokenProvider;
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+        var token = HeaderUtil.getAccessToken((HttpServletRequest) request);
+
+        if (token != null && tokenProvider.validateToken(token)) {
+            var authentication = tokenProvider.getAuthentication(token);
+            LocalContextHolder.setContext(authentication);
+        }
+        if(token == null){
+            request.setAttribute("noToken", Optional.ofNullable(null));
+        }
+        chain.doFilter(request, response);
+    }
+
+    @Override
+    public void destroy() {
+        LocalContextHolder.remove();
+    }
+}

--- a/src/main/java/com/core/service/auth/infrastructure/LocalContextHolder.java
+++ b/src/main/java/com/core/service/auth/infrastructure/LocalContextHolder.java
@@ -1,0 +1,20 @@
+package com.core.service.auth.infrastructure;
+
+import com.core.service.auth.domain.Authentication;
+import org.springframework.stereotype.Component;
+
+@Component
+public class LocalContextHolder {
+    private static final ThreadLocal<Authentication> context = new ThreadLocal<>();
+
+    public static Authentication getContext (){
+        return context.get();
+    }
+    public static void setContext(Authentication authentication){
+        context.set(authentication);
+    }
+
+    public static void remove(){
+        context.remove();
+    }
+}

--- a/src/main/java/com/core/service/auth/infrastructure/annotation/AuthMember.java
+++ b/src/main/java/com/core/service/auth/infrastructure/annotation/AuthMember.java
@@ -1,0 +1,11 @@
+package com.core.service.auth.infrastructure.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.PARAMETER, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AuthMember {
+}

--- a/src/main/java/com/core/service/auth/infrastructure/authentication/DefaultAuthenticationStrategy.java
+++ b/src/main/java/com/core/service/auth/infrastructure/authentication/DefaultAuthenticationStrategy.java
@@ -1,0 +1,20 @@
+package com.core.service.auth.infrastructure.authentication;
+
+import com.core.service.auth.domain.Authentication;
+import com.core.service.auth.infrastructure.LocalContextHolder;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.http.HttpServletRequest;
+
+@Component
+public class DefaultAuthenticationStrategy implements GetAuthenticationStrategy, SetAuthenticationStrategy{
+    @Override
+    public Authentication get(HttpServletRequest request) {
+        return LocalContextHolder.getContext();
+    }
+
+    @Override
+    public void set(Authentication authentication) {
+        LocalContextHolder.setContext(authentication);
+    }
+}

--- a/src/main/java/com/core/service/auth/infrastructure/authentication/GetAuthenticationStrategy.java
+++ b/src/main/java/com/core/service/auth/infrastructure/authentication/GetAuthenticationStrategy.java
@@ -1,0 +1,10 @@
+package com.core.service.auth.infrastructure.authentication;
+
+import com.core.service.auth.domain.Authentication;
+
+import javax.servlet.http.HttpServletRequest;
+
+public interface GetAuthenticationStrategy {
+    Authentication get(HttpServletRequest request);
+}
+

--- a/src/main/java/com/core/service/auth/infrastructure/authentication/SetAuthenticationStrategy.java
+++ b/src/main/java/com/core/service/auth/infrastructure/authentication/SetAuthenticationStrategy.java
@@ -1,0 +1,7 @@
+package com.core.service.auth.infrastructure.authentication;
+
+import com.core.service.auth.domain.Authentication;
+
+public interface SetAuthenticationStrategy {
+    void set(Authentication authentication);
+}

--- a/src/main/java/com/core/service/auth/presentation/AuthArgumentResolver.java
+++ b/src/main/java/com/core/service/auth/presentation/AuthArgumentResolver.java
@@ -1,0 +1,44 @@
+package com.core.service.auth.presentation;
+
+import com.core.service.auth.domain.UserDetail;
+import com.core.service.auth.infrastructure.annotation.AuthMember;
+import com.core.service.auth.infrastructure.authentication.DefaultAuthenticationStrategy;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.Objects;
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class AuthArgumentResolver implements HandlerMethodArgumentResolver {
+    private final DefaultAuthenticationStrategy defaultAuthenticationStrategy;
+
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return Objects.nonNull(parameter.getParameterAnnotation(AuthMember.class));
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer
+            , NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+        var httpServletRequest = webRequest.getNativeRequest(HttpServletRequest.class);
+        var userData = userInfo(httpServletRequest);
+        if (parameter.getParameterType() == Optional.class) {
+            return userData;
+        }
+        return userData.orElseThrow(NullPointerException::new);
+    }
+
+    private Optional<UserDetail> userInfo(HttpServletRequest request){
+        var userDetail = defaultAuthenticationStrategy.get(request).userDetail();
+        return Optional.ofNullable(userDetail);
+    }
+}

--- a/src/main/java/com/core/service/auth/presentation/AuthController.java
+++ b/src/main/java/com/core/service/auth/presentation/AuthController.java
@@ -1,0 +1,26 @@
+package com.core.service.auth.presentation;
+
+import com.core.service.auth.application.AuthService;
+import com.core.service.auth.dto.request.JoinRequest;
+import com.core.service.common.response.dto.ResponseDto;
+import com.core.service.common.response.dto.ResponseMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/v1/auth")
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/login")
+    public ResponseEntity<ResponseDto> login(@RequestBody JoinRequest request) {
+        var userDetail = authService.userLogin(request);
+
+        return ResponseDto.toResponseEntity(ResponseMessage.SUCCESS_LOAD_MEMBER_INFORMATION, userDetail);
+    }
+
+
+}

--- a/src/main/java/com/core/service/auth/token/TokenProvider.java
+++ b/src/main/java/com/core/service/auth/token/TokenProvider.java
@@ -1,0 +1,114 @@
+package com.core.service.auth.token;
+
+import com.core.service.auth.application.AuthService;
+import com.core.service.auth.domain.Authentication;
+import com.core.service.auth.domain.UserDetail;
+import com.core.service.common.util.DateUtil;
+import io.jsonwebtoken.*;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+import java.util.Base64;
+import java.util.Date;
+
+@Component
+@Slf4j
+public class TokenProvider {
+    private static final String AUTHORITIES_KEY = "roles";
+
+    @Value("${jwt.token.secret-key}")
+    private String secretKey;
+
+    @Value("${jwt.token.expiry}")
+    private Long tokenExpiry;
+
+    @Value("${jwt.token.refresh-expiry}")
+    private Long refreshTokenExpiry;
+
+    private final AuthService authService;
+
+    public TokenProvider(@Lazy AuthService authService) {
+        this.authService = authService;
+    }
+
+    @PostConstruct
+    public void init() {
+        secretKey = Base64.getEncoder().encodeToString(secretKey.getBytes());
+    }
+
+    /**
+     * @brief      * 토큰 생성 / jjwt 라이브러리
+     * @param      * claim : 데이터 (String userId)
+     *                  * Subject : 토큰 생성 목적
+     *             * IssuedAt : jwt 발급 시간
+     *             * Expiration Time : jwt 만료시간
+     *             * signWith : 암호화 알고리즘, secret 값 세팅
+     *             *
+     * @return     * access Jwt Token
+     */
+    public String generateJwtToken(Long userId, String role){
+        var claims = Jwts.claims().setSubject(String.valueOf(userId));
+        claims.put(AUTHORITIES_KEY, role);
+        var date = new Date();
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(date)
+                .signWith(SignatureAlgorithm.HS256, secretKey)
+                .setExpiration(DateUtil.getTokenValidTime(date, tokenExpiry))
+                .compact();
+    }
+
+    /**
+     * @brief      * 토큰 인증 정보 조회
+     * @param      * getUserToken : 파싱된 토큰
+     * @return     * Authentication : 유저 정보와 유저 역할
+     */
+    public Authentication getAuthentication(String token) {
+        UserDetail userDetail = authService.loadUserById(this.getUserToken(token));
+        return new Authentication(userDetail, userDetail.getRoleType());
+    }
+
+    /**
+     * @brief      * 토큰 파싱 (해석) / jjwt 라이브러리
+     * @param      * setSigningKey : jwt key
+     *             * parseClaimsJws : 파싱할 token
+     *             * Body : claims
+     *             * Subject : userId
+     * @return     * Long userId
+     */
+    public Long getUserToken(String token) {
+        var data = Jwts.parser()
+                .setSigningKey(secretKey)
+                .parseClaimsJws(token)
+                .getBody()
+                .getSubject();
+
+        return Long.parseLong(data);
+    }
+
+    /**
+     * @brief      * 토큰 기간 유효성 검사
+     * @param      * setSigningKey : jwt key
+     *             * parseClaimsJws : 파싱할 token
+     * @return     * token 기간
+     */
+
+    public boolean validateToken(String jwtToken) {
+        try {
+            Jws<Claims> claims = Jwts.parser().setSigningKey(secretKey).parseClaimsJws(jwtToken);
+            return claims.getBody().getExpiration().after(new Date());
+        } catch (ExpiredJwtException e)
+        {
+            log.error("토큰 만료");
+            return false;
+        }
+        catch (JwtException e)
+        {
+            log.error("jwt 에러");
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/core/service/common/header/HeaderUtil.java
+++ b/src/main/java/com/core/service/common/header/HeaderUtil.java
@@ -1,0 +1,24 @@
+package com.core.service.common.header;
+
+import javax.servlet.http.HttpServletRequest;
+
+public class HeaderUtil {
+    private final static String HEADER_AUTHORIZATION = "Authorization";
+    private final static String TOKEN_PREFIX = "Bearer ";
+
+    /**
+     * @brief      * token 헤더 조회
+     * @param      * HttpServletRequest : 요청 서블릿
+     * @return     * 토큰이 있다면 토큰 헤더 String, 없다면 null
+     */
+
+    public static String getAccessToken(HttpServletRequest request) {
+        String headerValue = request.getHeader(HEADER_AUTHORIZATION);
+
+        if (headerValue != null && headerValue.startsWith(TOKEN_PREFIX)) {
+            return headerValue.substring(TOKEN_PREFIX.length());
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/com/core/service/common/response/dto/ResponseMessage.java
+++ b/src/main/java/com/core/service/common/response/dto/ResponseMessage.java
@@ -6,7 +6,10 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum ResponseMessage {
 
-    SUCCESS(HttpStatus.OK,"SUCCESS");
+    SUCCESS(HttpStatus.OK,"SUCCESS"),
+    CREATE_SUCCESS_MEMBER(HttpStatus.CREATED, "멤버 회원 가인 성공"),
+    SUCCESS_LOAD_MEMBER_INFORMATION(HttpStatus.OK, "회원 정보 조회 성공"),
+    SUCCESS_SEARCH_ALL_MEMBER(HttpStatus.OK, "모든 회원 조회 성공");
 
     public final static String SUCCESS_MESSAGE = "SUCCESS";
     private final static String NOT_FOUND_MESSAGE = "NOT FOUND";

--- a/src/main/java/com/core/service/common/util/DateUtil.java
+++ b/src/main/java/com/core/service/common/util/DateUtil.java
@@ -1,0 +1,13 @@
+package com.core.service.common.util;
+
+import java.util.Date;
+
+public class DateUtil {
+    public static Date getDate(){
+        return new Date();
+    }
+
+    public static Date getTokenValidTime(Date date, Long validTime){
+        return new Date(date.getTime() + validTime);
+    }
+}

--- a/src/main/java/com/core/service/config/security/SecurityFilterConfig.java
+++ b/src/main/java/com/core/service/config/security/SecurityFilterConfig.java
@@ -1,0 +1,27 @@
+package com.core.service.config.security;
+
+import com.core.service.auth.application.AuthService;
+import com.core.service.auth.filter.JwtAuthenticationFilter;
+import com.core.service.auth.token.TokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.servlet.Filter;
+
+@Configuration
+@RequiredArgsConstructor
+public class SecurityFilterConfig {
+    private final TokenProvider tokenProvider;
+
+    @Bean
+    public FilterRegistrationBean<Filter> JwtAuthenticationCheckFilter() {
+        FilterRegistrationBean<Filter> filterFilterRegistrationBean = new FilterRegistrationBean<>();
+        filterFilterRegistrationBean.setFilter(new JwtAuthenticationFilter(tokenProvider));
+        filterFilterRegistrationBean.setOrder(1);
+        filterFilterRegistrationBean.addUrlPatterns("/*");
+
+        return filterFilterRegistrationBean;
+    }
+}

--- a/src/main/java/com/core/service/config/swagger/SwaggerConfig.java
+++ b/src/main/java/com/core/service/config/swagger/SwaggerConfig.java
@@ -6,6 +6,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 
+
 @Configuration
 public class SwaggerConfig {
     @Bean

--- a/src/main/java/com/core/service/error/dto/ErrorMessage.java
+++ b/src/main/java/com/core/service/error/dto/ErrorMessage.java
@@ -12,6 +12,10 @@ public enum ErrorMessage {
     SIGNATURE_EXCEPTION(HttpStatus.BAD_REQUEST, "잘못된 서명입니다."),
     MALFORMED_JWT_EXCEPTION(HttpStatus.BAD_REQUEST, "잘못된 JWT 형식입니다"),
     EXPIRED_JWT_EXCEPTION(HttpStatus.BAD_REQUEST, "토큰이 만료되었습니다"),
+    INVALID_EMAIL_REGEX_EXCEPTION(HttpStatus.BAD_REQUEST, "잘못된 이메일 형식입니다"),
+    INVALID_PASSWORD_REGEX_EXCEPTION(HttpStatus.BAD_REQUEST, "잘못된 비밀번호 형식입니다"),
+    INVALID_NAME_REGEX_EXCEPTION(HttpStatus.BAD_REQUEST, "잘못된 이름 형식 입니다"),
+    INVALID_CLASS_NUMBER_REGEX_EXCEPTION(HttpStatus.BAD_REQUEST, "잘못된 학번 형식 입니다"),
     NOT_EXIST_MEMBER_EXCEPTION(HttpStatus.NOT_FOUND, "해당 유저가 존재하지 않습니다"),
     ALREADY_EXIST_MEMBER_EMAIL_EXCEPTION(HttpStatus.BAD_REQUEST, "이미 해당 이메일 정보가 등록되어 있습니다.");
 

--- a/src/main/java/com/core/service/error/exception/member/ExpiredJwtException.java
+++ b/src/main/java/com/core/service/error/exception/member/ExpiredJwtException.java
@@ -1,0 +1,18 @@
+package com.core.service.error.exception.member;
+
+import com.core.service.error.dto.ErrorMessage;
+import com.core.service.error.exception.BusinessException;
+
+public class ExpiredJwtException extends BusinessException {
+    public ExpiredJwtException(ErrorMessage message) {
+        super(message);
+    }
+
+    public ExpiredJwtException(ErrorMessage message, String reason) {
+        super(message, reason);
+    }
+
+    public ExpiredJwtException(String reason) {
+        super(reason);
+    }
+}

--- a/src/main/java/com/core/service/error/exception/member/InvalidClassNumberException.java
+++ b/src/main/java/com/core/service/error/exception/member/InvalidClassNumberException.java
@@ -1,0 +1,18 @@
+package com.core.service.error.exception.member;
+
+import com.core.service.error.dto.ErrorMessage;
+import com.core.service.error.exception.BusinessException;
+
+public class InvalidClassNumberException extends BusinessException {
+    public InvalidClassNumberException(ErrorMessage message) {
+        super(message);
+    }
+
+    public InvalidClassNumberException(ErrorMessage message, String reason) {
+        super(message, reason);
+    }
+
+    public InvalidClassNumberException(String reason) {
+        super(reason);
+    }
+}

--- a/src/main/java/com/core/service/error/exception/member/InvalidEmailException.java
+++ b/src/main/java/com/core/service/error/exception/member/InvalidEmailException.java
@@ -1,0 +1,18 @@
+package com.core.service.error.exception.member;
+
+import com.core.service.error.dto.ErrorMessage;
+import com.core.service.error.exception.BusinessException;
+
+public class InvalidEmailException extends BusinessException {
+    public InvalidEmailException(ErrorMessage message) {
+        super(message);
+    }
+
+    public InvalidEmailException(ErrorMessage message, String reason) {
+        super(message, reason);
+    }
+
+    public InvalidEmailException(String reason) {
+        super(reason);
+    }
+}

--- a/src/main/java/com/core/service/error/exception/member/InvalidNameException.java
+++ b/src/main/java/com/core/service/error/exception/member/InvalidNameException.java
@@ -1,0 +1,18 @@
+package com.core.service.error.exception.member;
+
+import com.core.service.error.dto.ErrorMessage;
+import com.core.service.error.exception.BusinessException;
+
+public class InvalidNameException extends BusinessException {
+    public InvalidNameException(ErrorMessage message) {
+        super(message);
+    }
+
+    public InvalidNameException(ErrorMessage message, String reason) {
+        super(message, reason);
+    }
+
+    public InvalidNameException(String reason) {
+        super(reason);
+    }
+}

--- a/src/main/java/com/core/service/error/exception/member/InvalidPasswordException.java
+++ b/src/main/java/com/core/service/error/exception/member/InvalidPasswordException.java
@@ -1,0 +1,18 @@
+package com.core.service.error.exception.member;
+
+import com.core.service.error.dto.ErrorMessage;
+import com.core.service.error.exception.BusinessException;
+
+public class InvalidPasswordException extends BusinessException {
+    public InvalidPasswordException(ErrorMessage message) {
+        super(message);
+    }
+
+    public InvalidPasswordException(ErrorMessage message, String reason) {
+        super(message, reason);
+    }
+
+    public InvalidPasswordException(String reason) {
+        super(reason);
+    }
+}

--- a/src/main/java/com/core/service/error/exception/member/MalformedJwtException.java
+++ b/src/main/java/com/core/service/error/exception/member/MalformedJwtException.java
@@ -1,0 +1,18 @@
+package com.core.service.error.exception.member;
+
+import com.core.service.error.dto.ErrorMessage;
+import com.core.service.error.exception.BusinessException;
+
+public class MalformedJwtException extends BusinessException {
+    public MalformedJwtException(ErrorMessage message) {
+        super(message);
+    }
+
+    public MalformedJwtException(ErrorMessage message, String reason) {
+        super(message, reason);
+    }
+
+    public MalformedJwtException(String reason) {
+        super(reason);
+    }
+}

--- a/src/main/java/com/core/service/error/exception/member/NotExistMemberException.java
+++ b/src/main/java/com/core/service/error/exception/member/NotExistMemberException.java
@@ -1,0 +1,18 @@
+package com.core.service.error.exception.member;
+
+import com.core.service.error.dto.ErrorMessage;
+import com.core.service.error.exception.BusinessException;
+
+public class NotExistMemberException extends BusinessException {
+    public NotExistMemberException(ErrorMessage message) {
+        super(message);
+    }
+
+    public NotExistMemberException(ErrorMessage message, String reason) {
+        super(message, reason);
+    }
+
+    public NotExistMemberException(String reason) {
+        super(reason);
+    }
+}

--- a/src/main/java/com/core/service/error/exception/member/SignatureException.java
+++ b/src/main/java/com/core/service/error/exception/member/SignatureException.java
@@ -1,0 +1,18 @@
+package com.core.service.error.exception.member;
+
+import com.core.service.error.dto.ErrorMessage;
+import com.core.service.error.exception.BusinessException;
+
+public class SignatureException extends BusinessException {
+    public SignatureException(ErrorMessage message){
+        super(message);
+    }
+
+    public SignatureException(ErrorMessage message, String reason) {
+        super(message, reason);
+    }
+
+    public SignatureException(String reason) {
+        super(reason);
+    }
+}

--- a/src/main/java/com/core/service/member/application/MemberService.java
+++ b/src/main/java/com/core/service/member/application/MemberService.java
@@ -26,7 +26,7 @@ public class MemberService {
 
     @Transactional
     public MemberResponse joinMember(CreateMemberRequest request) {
-        duplicateValidationMemberEmail(request.getMemberEmail());
+        duplicateValidationMemberEmail(request.getEmail());
         var response = memberRepository.save(request.toEntity());
 
         return response.toResponseDto();

--- a/src/main/java/com/core/service/member/application/MemberService.java
+++ b/src/main/java/com/core/service/member/application/MemberService.java
@@ -32,7 +32,6 @@ public class MemberService {
         return response.toResponseDto();
     }
 
-
     public List<MemberResponse> searchAllMember() {
         var response = memberRepository.findAll().stream()
                 .map(member -> member.toResponseDto())
@@ -42,7 +41,7 @@ public class MemberService {
 
     @Transactional(readOnly = true)
     public void duplicateValidationMemberEmail(String email){
-        memberRepository.findByMemberEmail(email)
+        memberRepository.findByEmail(email)
                 .ifPresent(member -> {
                     throw new AlreadyExistMemberEmailException(ErrorMessage.ALREADY_EXIST_MEMBER_EMAIL_EXCEPTION, "이미 존재하는 이메일 정보입니다");
                 });

--- a/src/main/java/com/core/service/member/domain/Member.java
+++ b/src/main/java/com/core/service/member/domain/Member.java
@@ -1,7 +1,7 @@
 package com.core.service.member.domain;
 
 import com.core.service.common.domain.BaseEntity;
-import com.core.service.member.domain.vo.RoleType;
+import com.core.service.member.domain.vo.*;
 import com.core.service.member.dto.response.MemberResponse;
 import lombok.*;
 
@@ -26,7 +26,7 @@ public class Member extends BaseEntity {
     private String name;
 
     @Column
-    private String grade;
+    private Long grade;
 
     @Column
     private String classNumber;
@@ -36,13 +36,13 @@ public class Member extends BaseEntity {
     private RoleType roleType;
 
     @Builder
-    public Member(String memberEmail, String memberPassword, String name,
-                  String grade, String classNumber){
-        this.email = memberEmail;
-        this.password = memberPassword;
-        this.name = name;
+    public Member(String email, String password, String name,
+                  Long grade, String classNumber){
+        this.email = new Email(email).getEmail();
+        this.password = new Password(password).getPassword();
+        this.name = new Name(name).getName();
         this.grade = grade;
-        this.classNumber = classNumber;
+        this.classNumber = new ClassNumber(classNumber).getClassNumber();
         this.roleType = RoleType.LAB_USER;
     }
 

--- a/src/main/java/com/core/service/member/domain/Member.java
+++ b/src/main/java/com/core/service/member/domain/Member.java
@@ -17,10 +17,10 @@ public class Member extends BaseEntity {
     private Long id;
 
     @Column
-    private String memberEmail;
+    private String email;
 
     @Column
-    private String memberPassword;
+    private String password;
 
     @Column
     private String name;
@@ -38,8 +38,8 @@ public class Member extends BaseEntity {
     @Builder
     public Member(String memberEmail, String memberPassword, String name,
                   String grade, String classNumber){
-        this.memberEmail = memberEmail;
-        this.memberPassword = memberPassword;
+        this.email = memberEmail;
+        this.password = memberPassword;
         this.name = name;
         this.grade = grade;
         this.classNumber = classNumber;
@@ -49,7 +49,7 @@ public class Member extends BaseEntity {
     public MemberResponse toResponseDto(){
         return MemberResponse.builder()
                 .id(id)
-                .email(memberEmail)
+                .email(email)
                 .name(name)
                 .grade(grade)
                 .classNumber(classNumber)

--- a/src/main/java/com/core/service/member/domain/vo/ClassNumber.java
+++ b/src/main/java/com/core/service/member/domain/vo/ClassNumber.java
@@ -1,0 +1,24 @@
+package com.core.service.member.domain.vo;
+
+import com.core.service.error.dto.ErrorMessage;
+import com.core.service.error.exception.member.InvalidEmailException;
+import lombok.Getter;
+
+import java.util.regex.Pattern;
+
+@Getter
+public class ClassNumber {
+    private static final String CLASS_CLASS_NUMBER_REGEX = "^[0-9]{2}학번$";
+    private String classNumber;
+
+    public ClassNumber(String classNumber) {
+        validateEmail(classNumber);
+    }
+
+    private void validateEmail(String classNumber) {
+        if(!Pattern.matches(CLASS_CLASS_NUMBER_REGEX, classNumber)){
+            throw new InvalidEmailException(ErrorMessage.INVALID_CLASS_NUMBER_REGEX_EXCEPTION, "유효한 학번이 아닙니다");
+        };
+        this.classNumber = classNumber;
+    }
+}

--- a/src/main/java/com/core/service/member/domain/vo/Email.java
+++ b/src/main/java/com/core/service/member/domain/vo/Email.java
@@ -1,0 +1,24 @@
+package com.core.service.member.domain.vo;
+
+import com.core.service.error.dto.ErrorMessage;
+import com.core.service.error.exception.member.InvalidEmailException;
+import lombok.Getter;
+
+import java.util.regex.Pattern;
+
+@Getter
+public class Email {
+    private static final String EMAIL_REGEX = "[0-9a-zA-Z]+(.[_a-z0-9-]+)*@(?:\\w+\\.)+\\w+$";
+    private String email;
+
+    public Email(String email) {
+        validateEmail(email);
+    }
+
+    private void validateEmail(String email) {
+        if(!Pattern.matches(EMAIL_REGEX, email)){
+            throw new InvalidEmailException(ErrorMessage.INVALID_EMAIL_REGEX_EXCEPTION, "유효한 이메일 형식이 아닙니다");
+        };
+        this.email = email;
+    }
+}

--- a/src/main/java/com/core/service/member/domain/vo/Name.java
+++ b/src/main/java/com/core/service/member/domain/vo/Name.java
@@ -1,0 +1,24 @@
+package com.core.service.member.domain.vo;
+
+import com.core.service.error.dto.ErrorMessage;
+import com.core.service.error.exception.member.InvalidEmailException;
+import lombok.Getter;
+
+import java.util.regex.Pattern;
+
+@Getter
+public class Name {
+    private static final String NAME_REGEX = "^[ㄱ-ㅎ가-힣]{1,5}$";
+    private String name;
+
+    public Name(String name) {
+        validateEmail(name);
+    }
+
+    private void validateEmail(String name) {
+        if(!Pattern.matches(NAME_REGEX, name)){
+            throw new InvalidEmailException(ErrorMessage.INVALID_NAME_REGEX_EXCEPTION, "유효한 이름이 아닙니다");
+        };
+        this.name = name;
+    }
+}

--- a/src/main/java/com/core/service/member/domain/vo/Password.java
+++ b/src/main/java/com/core/service/member/domain/vo/Password.java
@@ -1,0 +1,24 @@
+package com.core.service.member.domain.vo;
+
+import com.core.service.error.dto.ErrorMessage;
+import com.core.service.error.exception.member.InvalidEmailException;
+import lombok.Getter;
+
+import java.util.regex.Pattern;
+
+@Getter
+public class Password {
+    private static final String PASSWORD_REGEX = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[~!@#$%^&*()+|=])[A-Za-z\\d~!@#$%^&*()+|=]{8,16}$";
+    private String password;
+
+    public Password(String password) {
+        validatePassword(password);
+    }
+
+    private void validatePassword(String password) {
+        if(!Pattern.matches(PASSWORD_REGEX, password)){
+            throw new InvalidEmailException(ErrorMessage.INVALID_PASSWORD_REGEX_EXCEPTION, "유효한 비밀번호 형식이 아닙니다");
+        };
+        this.password = password;
+    }
+}

--- a/src/main/java/com/core/service/member/dto/request/CreateMemberRequest.java
+++ b/src/main/java/com/core/service/member/dto/request/CreateMemberRequest.java
@@ -1,15 +1,12 @@
 package com.core.service.member.dto.request;
 
 import com.core.service.member.domain.Member;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
+
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotNull;
 
 @Getter
-@NoArgsConstructor
-@AllArgsConstructor
 public class CreateMemberRequest {
     @Email
     @NotNull

--- a/src/main/java/com/core/service/member/dto/request/CreateMemberRequest.java
+++ b/src/main/java/com/core/service/member/dto/request/CreateMemberRequest.java
@@ -3,31 +3,33 @@ package com.core.service.member.dto.request;
 import com.core.service.member.domain.Member;
 import lombok.Getter;
 
-import javax.validation.constraints.Email;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
 @Getter
 public class CreateMemberRequest {
-    @Email
     @NotNull
-    private String memberEmail;
+    private String email;
 
     @NotNull
-    private String memberPassword;
+    private String password;
 
     @NotNull
     private String name;
 
     @NotNull
-    private String grade;
+    @Min(1)
+    @Max(4)
+    private Long grade;
 
     @NotNull
     private String classNumber;
 
     public Member toEntity(){
         return Member.builder()
-                .memberEmail(memberEmail)
-                .memberPassword(memberPassword)
+                .email(email)
+                .password(password)
                 .name(name)
                 .grade(grade)
                 .classNumber(classNumber)

--- a/src/main/java/com/core/service/member/dto/response/MemberResponse.java
+++ b/src/main/java/com/core/service/member/dto/response/MemberResponse.java
@@ -11,13 +11,13 @@ public class MemberResponse {
     private Long id;
     private String email;
     private String name;
-    private String grade;
+    private Long grade;
     private String classNumber;
     private RoleType roleType;
 
     @Builder
     public MemberResponse(Long id, String email, String name,
-                          String grade, String classNumber, RoleType roleType){
+                          Long grade, String classNumber, RoleType roleType){
         this.id = id;
         this.email = email;
         this.name = name;

--- a/src/main/java/com/core/service/member/infrastructure/MemberRepository.java
+++ b/src/main/java/com/core/service/member/infrastructure/MemberRepository.java
@@ -6,5 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
-    Optional<Member> findByMemberEmail(String memberEmail);
+    Optional<Member> findByEmail(String email);
+
+    Optional<Member> findByEmailAndPassword(String email, String password);
 }

--- a/src/main/java/com/core/service/member/presentaion/MemberController.java
+++ b/src/main/java/com/core/service/member/presentaion/MemberController.java
@@ -16,16 +16,25 @@ import javax.validation.Valid;
 public class MemberController {
     private final MemberService memberService;
 
+    /**
+     * @param CreateMemberRequest : 회원가입 유저 정보 Dto
+     * @todo 이후 토큰이 있는 상태라면 진행이 불가능하도록 추가 예정,
+     * @todp 이후 @Valid가 아닌 vo 생성자로 유효성 검사 진행 예정
+     * @return MemberResponse : 회원 정보 ResponseDto
+     */
     @PostMapping("/signup")
     public ResponseEntity<ResponseDto> joinMember(@RequestBody @Valid CreateMemberRequest request) {
         var response = memberService.joinMember(request);
-        return ResponseDto.toResponseEntity(ResponseMessage.CREATED, response);
+        return ResponseDto.toResponseEntity(ResponseMessage.CREATE_SUCCESS_MEMBER, response);
     }
 
+    /**
+     * @todo 일반 유저권한으로는 모든 멤버 조회 불가하도록 추가 예정
+     */
     @GetMapping
     public ResponseEntity<ResponseDto> searchAllMember() {
         var response = memberService.searchAllMember();
 
-        return ResponseDto.toResponseEntity(ResponseMessage.SUCCESS, response);
+        return ResponseDto.toResponseEntity(ResponseMessage.SUCCESS_SEARCH_ALL_MEMBER, response);
     }
 }


### PR DESCRIPTION
### 💡 개요
- Spring Securirty를 사용하지 않고 JWT를 이용한 인증 정보 처리
- 인증 정보를 처리하기 위한 클래스 생성
- 이후 코드리뷰 피드백을 통한 회원가입 시 객체 생성을 통한 유효성 검사 진행
- 요청 값(requestBody)에 대한 유효성 검사를 위한 validation 의존성 추가 
- resolved #14 

### 📑 작업 사항
- jwt에 보관할 유저 객체 생성

![Screen Shot 2023-08-14 at 11 13 21 PM](https://github.com/selab-hs/SE-Community-Service/assets/50690859/e2fd1c80-b593-42c4-887f-0fb5f621b4f4)

- 유저 정보 조회를 위한 AuthController/Service/Repository 구현

![Screen Shot 2023-08-14 at 11 15 14 PM](https://github.com/selab-hs/SE-Community-Service/assets/50690859/b63d8955-90cf-474a-a87a-c6b3661afa9f)

- TokenProvider.class 를 통한 jwt 관리

![Screen Shot 2023-08-14 at 11 16 27 PM](https://github.com/selab-hs/SE-Community-Service/assets/50690859/7243c266-0b30-4ad4-9b3a-8de5d62a42d4)

![Screen Shot 2023-08-14 at 11 16 35 PM](https://github.com/selab-hs/SE-Community-Service/assets/50690859/d8b4c365-1312-4652-80ab-a02908cdf9d5)

![Screen Shot 2023-08-14 at 11 16 58 PM](https://github.com/selab-hs/SE-Community-Service/assets/50690859/6e80fc3d-04bf-4e5d-930f-92f57f6facf2)

- jwt 토큰을 보관을 위한 LocalThread 사용

![Screen Shot 2023-08-14 at 11 18 40 PM](https://github.com/selab-hs/SE-Community-Service/assets/50690859/1168e849-71ed-40b2-8f0d-1d789be5d1fc)


- jwt 토큰을 가진 request를 LocalThread에 보관하기 위해 JwtAuthenticationFilter 구현

![Screen Shot 2023-08-14 at 11 19 05 PM](https://github.com/selab-hs/SE-Community-Service/assets/50690859/90de8ff1-79fc-4468-a8da-0ad291e11315)


- 유저 인증 정보를 사용하기 위한 AuthMember 어노테이션 생성 및 ArgumentResolver를 통한 연동

![Screen Shot 2023-08-14 at 11 19 41 PM](https://github.com/selab-hs/SE-Community-Service/assets/50690859/2ee837bb-6d12-4c04-a8c2-6bc89e647b98)

![Screen Shot 2023-08-14 at 11 19 30 PM](https://github.com/selab-hs/SE-Community-Service/assets/50690859/8b5186dc-3c41-41e3-960d-763a624b3f13)

--- 

### 📑 작업 사항 2
- 이메일 vo 객체 생성 (이메일 형식)

![Screen Shot 2023-08-16 at 9 53 05 PM](https://github.com/selab-hs/SE-Community-Service/assets/50690859/a8ebd986-63c0-4a55-b85f-520330d24234)

- 패스워드 vo 객체 생성 (특수문자, 영어, 숫자를 혼합합 8~16 자리)

![Screen Shot 2023-08-16 at 11 48 30 PM](https://github.com/selab-hs/SE-Community-Service/assets/50690859/ab4db161-0290-46a8-84c6-1a923dfd0a10)

- 이름 vo 객체 생성 (한글 다섯글자)

![Screen Shot 2023-08-16 at 11 56 24 PM](https://github.com/selab-hs/SE-Community-Service/assets/50690859/4dcb8e4c-7f54-4eb4-8404-d7199974020f)

- 학번 vo 객체 생성 (정수2개 + '학번' 문자열)

![Screen Shot 2023-08-16 at 11 49 16 PM](https://github.com/selab-hs/SE-Community-Service/assets/50690859/97504d14-b6f6-4b69-9482-bdcfa247b97b)

- 회원가입 요청 dto 학년 유효성검사 진행 및 Long 타입 변경

![Screen Shot 2023-08-16 at 11 49 39 PM](https://github.com/selab-hs/SE-Community-Service/assets/50690859/56796778-4e3f-4326-ba24-ac2c08a15985)

- Member Entity Builder 생성 시 객체를 통한 유효성 검사 진행

![Screen Shot 2023-08-16 at 11 49 54 PM](https://github.com/selab-hs/SE-Community-Service/assets/50690859/b59809a7-51c0-48f0-939b-190ab4fcc2aa)


### ✒️ 코드 리뷰 요청 사항
- 적용 사항 잘못된 부분 혹은 개선할 부분


### ✔️ 코드 리뷰 반영 사항
- ArguementResolver를 이용한 AuthMember 어노테이션 연결
- LocalTread를 이용하여 인증정보 가져오기/내보내기
- AuthService와 TokenProvider 클래스 순환 참조 @Lazy 생성을 통한 처리
- 회원가입 시 Email, Password, Name, ClassNumber 정규식을 통한 유효성 검사 진행