### PR TITLE
[Fix/Spring-Cloud-Aws] 로컬 환경 Aws Endpoint Exception 해결

### DIFF
--- a/src/main/java/com/core/service/config/spring/SpringConfig.java
+++ b/src/main/java/com/core/service/config/spring/SpringConfig.java
@@ -1,0 +1,22 @@
+package com.core.service.config.spring;
+
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.cloud.aws.autoconfigure.context.ContextInstanceDataAutoConfiguration;
+import org.springframework.cloud.aws.autoconfigure.context.ContextRegionProviderAutoConfiguration;
+import org.springframework.cloud.aws.autoconfigure.context.ContextStackAutoConfiguration;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableAutoConfiguration(exclude = {
+        ContextInstanceDataAutoConfiguration.class,
+        ContextStackAutoConfiguration.class,
+        ContextRegionProviderAutoConfiguration.class
+})
+public class SpringConfig {
+    /*
+        해당 설정은 Spring Cloud Aws 의존성이 추가 후
+        특정 엔드포인트가 AWS EC2 인스턴스에서만 접근이 되기 떄문에 로컬환경에서 에러 발생
+        해당 에러를 없애기 위해 로컬 환경에서 실행할 경우 설정을 통해 해당 클래스들을 자동 설정에서 제외한 것
+        이후 EC2 main 브랜치에서 실행할 경우 해당 클래스를 제거해야 함
+    */
+}


### PR DESCRIPTION
### 💡 개요
- Spring Cloud Aws Error 의존성 추가 이후 Failed to connect to service endpoint Exception 발생
- resolved #48 

### 📑 작업 사항
- 특정 엔드포인트가 AWS EC2 인스턴스에서만 접근이 되기 떄문에 로컬환경에서 에러 발생
- 해당 에러는 로컬환경에서 발생하는 문제로 SpringBootApplication excloud를 통하여 제외하였으나 Application 클래스가 지저분해지게 됨
![Screen Shot 2023-09-11 at 11 44 27 PM](https://github.com/selab-hs/SE-Community-Service/assets/50690859/4fed133b-d198-45be-a9a9-0800e192adc5)

- 설정 class를 따로 만들어서 해당 클래스들의 자동 주입을 제외하였음
![Screen Shot 2023-09-11 at 11 44 50 PM](https://github.com/selab-hs/SE-Community-Service/assets/50690859/b79acb0b-b7bf-4c73-a2dc-ee8761ab045e)

- 현재 로컬에서 작업 중 생기는 에러이고 이후 EC2 환경에서 필요한 경우가 생길 수 있으니 배포 브랜치인 main에서는 해당 파일 삭제 예정 

### ✒️ 코드 리뷰 요청 사항
- 더 나은 개선 사항


### ✔️ 코드 리뷰 반영 사항
- 없음