### PR TITLE
[Repactoring/Member-State] 유저 권한 및 역할 분리

### DIFF
--- a/src/main/java/com/hs/selab/auth/domain/UserDetail.java
+++ b/src/main/java/com/hs/selab/auth/domain/UserDetail.java
@@ -1,6 +1,7 @@
 package com.hs.selab.auth.domain;
 
 import com.hs.selab.member.domain.Member;
+import com.hs.selab.member.domain.vo.MemberState;
 import com.hs.selab.member.domain.vo.RoleType;
 import lombok.Getter;
 
@@ -8,19 +9,19 @@ import lombok.Getter;
 public class UserDetail {
     private Long id;
     private String userEmail;
-    private String userPassword;
     private String name;
     private Long grade;
     private String studentID;
+    private MemberState state;
     private RoleType roleType;
 
     public UserDetail(Member member) {
         this.id = member.getId();
         this.userEmail = member.getEmail().getEmail();
-        this.userPassword = member.getPassword();
         this.name = member.getName().getName();
         this.grade = member.getGrade();
         this.studentID = member.getStudentId().getStudentId();
+        this.state = member.getState();
         this.roleType = member.getRoleType();
     }
 

--- a/src/main/java/com/hs/selab/board/application/BoardService.java
+++ b/src/main/java/com/hs/selab/board/application/BoardService.java
@@ -57,7 +57,7 @@ public class BoardService {
 
    @Transactional
     public Long create(CreateBoardRequest request, UserDetail userInfo){
-        if (!userInfo.getRoleType().equals(RoleType.LAB_USER))
+        if (!userInfo.getRoleType().equals(RoleType.USER))
         {
             throw new UnauthorizedAccessException(
                 UNAUTHORIZED_ACCESS_EXCEPTION,

--- a/src/main/java/com/hs/selab/comment/application/CommentService.java
+++ b/src/main/java/com/hs/selab/comment/application/CommentService.java
@@ -26,7 +26,7 @@ public class CommentService {
 
     @Transactional
     public void create(CreateCommentRequest request, UserDetail userInfo) {
-        if (!userInfo.getRoleType().equals(RoleType.LAB_USER)) {
+        if (!userInfo.getRoleType().equals(RoleType.USER)) {
             throw new UnauthorizedAccessException(
                 UNAUTHORIZED_ACCESS_EXCEPTION,
                 "권한이 없는 접근입니다."
@@ -53,7 +53,7 @@ public class CommentService {
 
     @Transactional(readOnly = true)
     public List<ReadCommentResponse> getAll(ReadCommentRequest request, UserDetail userInfo) {
-        if (!userInfo.getRoleType().equals(RoleType.LAB_USER)) {
+        if (!userInfo.getRoleType().equals(RoleType.USER)) {
             throw new UnauthorizedAccessException(
                 UNAUTHORIZED_ACCESS_EXCEPTION,
                 "권한이 없는 접근입니다."

--- a/src/main/java/com/hs/selab/member/domain/Member.java
+++ b/src/main/java/com/hs/selab/member/domain/Member.java
@@ -41,6 +41,10 @@ public class Member extends BaseEntity {
     @Enumerated
     private RoleType roleType;
 
+    @Column
+    @Enumerated
+    private MemberState state;
+
     @Builder
     public Member(String email, String password, String name,
                   Long grade, String studentId){
@@ -49,7 +53,8 @@ public class Member extends BaseEntity {
         this.name = new Name(name);
         this.grade = grade;
         this.studentId = new StudentId(studentId);
-        this.roleType = RoleType.LAB_USER;
+        this.state = MemberState.ENROLLED;
+        this.roleType = RoleType.USER;
     }
 
     public MemberResponse toResponseDto(){
@@ -59,6 +64,7 @@ public class Member extends BaseEntity {
                 .name(name.getName())
                 .grade(grade)
                 .studentId(studentId.getStudentId())
+                .state(this.state)
                 .roleType(roleType)
                 .build();
     }

--- a/src/main/java/com/hs/selab/member/domain/vo/MemberState.java
+++ b/src/main/java/com/hs/selab/member/domain/vo/MemberState.java
@@ -1,0 +1,15 @@
+package com.hs.selab.member.domain.vo;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum MemberState {
+    ENROLLED("재학생"),
+    ON_LEAVE("휴학생"),
+    GRADUATED( "졸업생"),
+    LAB_LEADER("랩장");
+
+    private final String state;
+}

--- a/src/main/java/com/hs/selab/member/domain/vo/RoleType.java
+++ b/src/main/java/com/hs/selab/member/domain/vo/RoleType.java
@@ -7,8 +7,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum RoleType {
     GUEST("GUEST", "게스트"),
-    LAB_USER("ROLE_USER", "랩원"),
-    LAB_LEADER("ROLE_LEADER", "랩장");
+    USER("ROLE_USER", "유저"),
+    ADMIN("ROLE_ADMIN", "관리자");
 
     private final String role;
     private final String value;

--- a/src/main/java/com/hs/selab/member/dto/response/MemberResponse.java
+++ b/src/main/java/com/hs/selab/member/dto/response/MemberResponse.java
@@ -1,5 +1,6 @@
 package com.hs.selab.member.dto.response;
 
+import com.hs.selab.member.domain.vo.MemberState;
 import com.hs.selab.member.domain.vo.RoleType;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,16 +14,19 @@ public class MemberResponse {
     private String name;
     private Long grade;
     private String studentId;
+    private MemberState state;
     private RoleType roleType;
 
     @Builder
     public MemberResponse(Long id, String email, String name,
-                          Long grade, String studentId, RoleType roleType){
+                          Long grade, String studentId,
+                          MemberState state, RoleType roleType){
         this.id = id;
         this.email = email;
         this.name = name;
         this.grade = grade;
         this.studentId = studentId;
+        this.state = state;
         this.roleType = roleType;
     }
 }

--- a/src/main/java/com/hs/selab/post/application/PostService.java
+++ b/src/main/java/com/hs/selab/post/application/PostService.java
@@ -42,7 +42,7 @@ public class PostService {
             UserDetail userInfo,
             Long boardId
     ) {
-        if (!userInfo.getRoleType().equals(RoleType.LAB_USER)) {
+        if (!userInfo.getRoleType().equals(RoleType.USER)) {
             throw new UnauthorizedAccessException(
                     UNAUTHORIZED_ACCESS_EXCEPTION,
                     "권한이 없는 접근입니다."
@@ -84,7 +84,7 @@ public class PostService {
             Long postId,
             UserDetail userInfo
     ) {
-        if (!userInfo.getRoleType().equals(RoleType.LAB_USER)) {
+        if (!userInfo.getRoleType().equals(RoleType.USER)) {
             throw new UnauthorizedAccessException(
                     UNAUTHORIZED_ACCESS_EXCEPTION,
                     "권한이 없는 접근입니다."


### PR DESCRIPTION
### 💡 개요
- 유저 권한과 역할(상태) 간에 모호함 존재
- resolved #67 

### 📑 작업 사항
- 유저 권한을 게스트, 유저, 관리자로 변경
- 유저 엔티티에 유저 상태 VO 객체 추가. 재학생, 휴학생, 졸업생, 랩장으로 구분


### ✒️ 코드 리뷰 요청 사항
- 개선사항 유무